### PR TITLE
Riak ruby client 2.6

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,12 @@
-# `ripple`: Riak Document Models [![Build Status](https://secure.travis-ci.org/basho-labs/ripple.png)](http://travis-ci.org/basho-labs/ripple)
+# `ripple`: Riak Document Models
 
 `ripple` is a rich Ruby modeling layer for Riak, Basho's distributed
 database that contains an ActiveModel-based document abstraction which
 is inspired by ActiveRecord, DataMapper, and MongoMapper.
+
+At Spreedly we use a small subset of ripple's features: mostly the
+`Ripple::Document` declarations wrapped in our own abstraction called
+`CoreDocument` or `IdDocument`.
 
 ## Dependencies
 
@@ -21,7 +25,7 @@ $ bundle install
 
 To run the specs first bring up the [riak-ruby-vagrant](https://github.com/basho-labs/riak-ruby-vagrant) virtual machine.
 
-THen you can run the RSpec suite using `bundle exec`:
+Then you can run the RSpec suite using `bundle exec`:
 
 ``` bash
 $ bundle exec rake spec
@@ -93,7 +97,6 @@ Configure in an initializer:
 ```ruby
 Ripple.config = {
   host: "127.0.0.1",
-  http_port: ENV["RIAK_HTTP_PORT"] || 8098,
   pb_port: ENV["RIAK_PB_PORT"] || 8087
 }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,9 @@ get started:
 $ bundle install
 ```
 
-Run the RSpec suite using `bundle exec`:
+To run the specs first bring up the [riak-ruby-vagrant](https://github.com/basho-labs/riak-ruby-vagrant) virtual machine.
+
+THen you can run the RSpec suite using `bundle exec`:
 
 ``` bash
 $ bundle exec rake spec

--- a/RELEASE_NOTES.textile
+++ b/RELEASE_NOTES.textile
@@ -1,5 +1,20 @@
 h1. Ripple Release Notes
 
+h2. 3.0.0 Major Release
+
+Update to riak-ruby-client 2.x
+
+* Update the riak-ruby-client dependency to 2.6.0 or above
+* Switch to using Basho's [Riak Ruby Vagrant](https://github.com/basho-labs/riak-ruby-vagrant) virtual machine for local testing instead of a Docker instance.
+
+The Riak Ruby Client 2.x series does a few major things:
+
+* Supports making authenticated connections to Riak
+* Drops support for HTTP connections to Riak
+* Drops support for link walking (already no longer supported by Riak)
+
+[Full Riak Ruby Client 2.x release notes](https://github.com/basho/riak-ruby-client/blob/master/RELNOTES.md#200-release---2014-09-05)
+
 h2. 2.2.0 Rails 4.2 Upgrade
 
 Updates for activemodel and activesupport related to Rails 4.2.

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,14 @@ require 'rubygems/package_task'
 require 'rspec/core'
 require 'rspec/core/rake_task'
 
+# "fix" NoMethodError: undefined method `last_comment'
+module StubRakeLastComment
+  def last_comment
+    last_description
+  end
+end
+Rake::Application.send :include, StubRakeLastComment
+
 def gemspec
   $ripple_gemspec ||= Gem::Specification.load("ripple.gemspec")
 end

--- a/lib/ripple/version.rb
+++ b/lib/ripple/version.rb
@@ -1,3 +1,3 @@
 module Ripple
-  VERSION = "2.2.0"
+  VERSION = "3.0.0"
 end

--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~>2.8.0"
   gem.add_development_dependency "rake"
 
-  gem.add_dependency "riak-client", "~> 1.1"
+  gem.add_dependency "riak-client", "~> 2.6"
   gem.add_dependency "activesupport", "~> 4.2.0"
   gem.add_dependency "activemodel", "~> 4.2.0"
   gem.add_dependency "tzinfo"

--- a/spec/ripple/finders_spec.rb
+++ b/spec/ripple/finders_spec.rb
@@ -78,18 +78,18 @@ describe Ripple::Document::Finders do
     end
 
     it "should return nil when no object exists at that key" do
-      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       box = Box.find("square")
       box.should be_nil
     end
 
     it "should raise DocumentNotFound when using find! if no object exists at that key" do
-      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       lambda { Box.find!("square") }.should raise_error(Ripple::DocumentNotFound, "Couldn't find document with key: square")
     end
 
     it "should re-raise the failed request exception if not a 404" do
-      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 500, {}, "500 internal server error"))
+      @bucket.should_receive(:get).with("square", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:internal_server_error, "internal server error"))
       lambda { Box.find("square") }.should raise_error(Riak::FailedRequest)
     end
 
@@ -121,7 +121,7 @@ describe Ripple::Document::Finders do
     describe "when using find with missing keys" do
       before :each do
         @bucket.should_receive(:get).with("square", {}).and_return(@plain)
-        @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+        @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       end
 
       it "should return nil for documents that no longer exist" do
@@ -161,7 +161,7 @@ describe Ripple::Document::Finders do
     describe "when using find with missing keys" do
       before :each do
         @bucket.should_receive(:get).with("square", {}).and_return(@plain)
-        @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+        @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       end
 
       it "should return nil for documents that no longer exist" do
@@ -187,7 +187,7 @@ describe Ripple::Document::Finders do
     it "should exclude objects that are not found" do
       @bucket.should_receive(:keys).and_return(["square", "rectangle"])
       @bucket.should_receive(:get).with("square", {}).and_return(@plain)
-      @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+      @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       boxes = Box.list
       boxes.should have(1).item
       boxes.first.shape.should == "square"
@@ -196,7 +196,7 @@ describe Ripple::Document::Finders do
     it "should yield found objects to the passed block, excluding missing objects, and return an empty array" do
       @bucket.should_receive(:keys).and_yield(["square"]).and_yield(["rectangle"])
       @bucket.should_receive(:get).with("square", {}).and_return(@plain)
-      @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::HTTPFailedRequest.new(:get, 200, 404, {}, "404 not found"))
+      @bucket.should_receive(:get).with("rectangle", {}).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
       @block = mock()
       @block.should_receive(:ping).once
       Box.list do |box|

--- a/spec/ripple/persistence_spec.rb
+++ b/spec/ripple/persistence_spec.rb
@@ -108,7 +108,7 @@ describe Ripple::Document::Persistence do
 
   it "should allow unexpected exceptions to be raised" do
     robject = mock("robject", :key => @widget.key, "data=" => true, "content_type=" => true, "indexes=" => true)
-    robject.should_receive(:store).and_raise(Riak::HTTPFailedRequest.new(:post, 200, 404, {}, "404 not found"))
+    robject.should_receive(:store).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, "not found"))
     @widget.stub!(:robject).and_return(robject)
     lambda { @widget.save }.should raise_error(Riak::FailedRequest)
   end

--- a/spec/ripple/ripple_spec.rb
+++ b/spec/ripple/ripple_spec.rb
@@ -21,16 +21,16 @@ describe Ripple do
 
   it "should allow setting the client manually" do
     Ripple.should respond_to(:client=)
-    client = Riak::Client.new(:http_port => 9000)
+    client = Riak::Client.new(:pb_port => 9000)
     Ripple.client = client
     Ripple.client.should == client
   end
 
   it "should reset the client when the configuration changes" do
     c = Ripple.client
-    Ripple.config = {:http_port => 9000}
+    Ripple.config = {:pb_port => 9000}
     Ripple.client.should_not == c
-    Ripple.client.node.http_port.should == 9000
+    Ripple.client.node.pb_port.should == 9000
   end
 
   describe "date format" do

--- a/spec/ripple/validations_spec.rb
+++ b/spec/ripple/validations_spec.rb
@@ -64,7 +64,7 @@ describe Ripple::Validations do
 
   it "should allow unexpected exceptions to be raised" do
     robject = mock("robject", :key => subject.key, "data=" => true, "content_type=" => true, "indexes=" => true)
-    robject.should_receive(:store).and_raise(Riak::HTTPFailedRequest.new(:post, 200, 404, {}, "404 not found"))
+    robject.should_receive(:store).and_raise(Riak::ProtobuffsFailedRequest.new(:not_found, 'not found'))
     subject.stub!(:robject).and_return(robject)
     subject.stub!(:valid?).and_return(true)
     lambda { subject.save! }.should raise_error(Riak::FailedRequest)

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -1,23 +1,14 @@
 require 'riak_test_server'
 
-TEST_SERVER_HTTP_PORT = 10400
-TEST_SERVER_PB_PORT = 10500
+TEST_SERVER_HTTP_PORT = 17017
+TEST_SERVER_PB_PORT = 17018
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    RiakTestServer.setup(
-      http_port: TEST_SERVER_HTTP_PORT,
-      pb_port: TEST_SERVER_PB_PORT,
-      container_name: "ripple_tests"
-    )
-  end
-
   config.before(:each, integration: true) do
-    RiakTestServer.clear
     Ripple.config = {
       nodes: [
         {
-          host: "docker",
+          host: "localhost",
           http_port: TEST_SERVER_HTTP_PORT,
           pb_port: TEST_SERVER_PB_PORT
         }

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -9,7 +9,6 @@ RSpec.configure do |config|
       nodes: [
         {
           host: "localhost",
-          http_port: TEST_SERVER_HTTP_PORT,
           pb_port: TEST_SERVER_PB_PORT
         }
       ]


### PR DESCRIPTION
This is a major version update to the ruby client. The most notable changes:

- HTTP connections to Riak are no longer supported by the client,
  now it's protobuffs or nothing
- link walking (which is reportedly deprecated in Riak 2) is no longer
  supported by the client
- Authenticated connections to Riak are supported

Full 2.x details:
https://github.com/basho/riak-ruby-client/blob/master/RELNOTES.md#200-release---2014-09-05

We're bringing this in primarily because we're going to be enabling secure connections to Riak and support for those are only available in the 2.x versions of the riak-ruby-client.