### PR TITLE
Deprecate linked associations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,12 +23,10 @@ get started:
 $ bundle install
 ```
 
-To run the specs first bring up the [riak-ruby-vagrant](https://github.com/basho-labs/riak-ruby-vagrant) virtual machine.
-
 Then you can run the RSpec suite using `bundle exec`:
 
 ``` bash
-$ bundle exec rake spec
+$ bundle exec rake spec:all
 ```
 
 ## Document Model Examples

--- a/RELEASE_NOTES.textile
+++ b/RELEASE_NOTES.textile
@@ -1,5 +1,10 @@
 h1. Ripple Release Notes
 
+h2. 3.1.0 Release
+
+* Deprecate linked associations. All support for linked associations will be dropped in a future release.
+* Switch back to [Riak Test Server](https://github.com/spreedly/riak_test_server) for local testing instead of Basho's defunct Vagrant virtual machine.
+
 h2. 3.0.0 Major Release
 
 Update to riak-ruby-client 2.x

--- a/lib/ripple/associations/linked.rb
+++ b/lib/ripple/associations/linked.rb
@@ -47,6 +47,7 @@ module Ripple
       end
 
       def robjects
+        ActiveSupport::Deprecation.warn("Link walking and linked associations are deprecated and will be removed in a future release of Ripple.")
         walk_result = begin
           @owner.robject.walk(*Array(@reflection.link_spec)).first || []
         rescue

--- a/lib/ripple/conflict/test_helper.rb
+++ b/lib/ripple/conflict/test_helper.rb
@@ -13,9 +13,6 @@ module Ripple
           records = modifiers.map { |_| klass.find!(key) }
 
           records.zip(modifiers).each do |(record, modifier)|
-            # necessary to get conflict on 0.14 and earlier, so riak thinks they are being saved by different clients
-            Ripple.client.client_id += 1
-
             modifier.call(record)
             record.save! unless record.deleted?
           end

--- a/lib/ripple/version.rb
+++ b/lib/ripple/version.rb
@@ -1,3 +1,3 @@
 module Ripple
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |gem|
   ignores = File.read(".gitignore").split(/\r?\n/).reject{ |f| f =~ /^(#.+|\s*)$/ }.map {|f| Dir[f] }.flatten
   gem.files         = (Dir['**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }
   gem.test_files    = (Dir['spec/**/*','.gitignore'] - ignores).reject {|f| !File.file?(f) }
-  # gem.executables   = Dir['bin/*'].map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 end

--- a/spec/integration/ripple/associations_spec.rb
+++ b/spec/integration/ripple/associations_spec.rb
@@ -91,6 +91,7 @@ describe "Ripple Associations" do
   end
 
   it "should save a many linked association" do
+    pending("Linked associations are deprecated")
     @user.friends << @friend1 << @friend2
     @user.save
     @user.should_not be_new_record
@@ -100,6 +101,7 @@ describe "Ripple Associations" do
   end
 
   it "should save a one linked association" do
+    pending("Linked associations are deprecated")
     @user.emergency_contact = @friend1
     @user.save
     @user.should_not be_new_record
@@ -108,6 +110,7 @@ describe "Ripple Associations" do
   end
 
   it "should reload associations" do
+    pending("Linked associations are deprecated")
     @user.friends << @friend1
     @user.save!
 
@@ -120,6 +123,7 @@ describe "Ripple Associations" do
   end
 
   it "allows and autosaves transitive linked associations" do
+    pending("Linked associations are deprecated")
     friend = User.new(:email => 'user-friend@example.com')
     friend.key = 'main-user-friend'
     @user.key = 'main-user'

--- a/spec/integration/ripple/conflict_resolution_spec.rb
+++ b/spec/integration/ripple/conflict_resolution_spec.rb
@@ -240,6 +240,7 @@ describe "Ripple conflict resolution", :integration => true do
     end
 
     it 'sets the association to nil and includes its name in the list of conflicts passed to the on_conflict block' do
+      pending("Linked associations are deprecated")
       record_spouse = conflicts = sibling_spouse_names = nil
 
       ConflictedPerson.on_conflict do |siblings, c|
@@ -263,6 +264,7 @@ describe "Ripple conflict resolution", :integration => true do
     end
 
     it 'sets the association to a blank array and includes its name in the list of conflicts passed to the on_conflict block' do
+      pending("Linked associations are deprecated")
       record_friends = conflicts = sibling_friend_names = nil
 
       ConflictedPerson.on_conflict do |siblings, c|

--- a/spec/integration/ripple/nested_attributes_spec.rb
+++ b/spec/integration/ripple/nested_attributes_spec.rb
@@ -2,13 +2,6 @@ require 'spec_helper'
 require 'active_support/core_ext/array'
 
 describe Ripple::NestedAttributes, :integration => true do
-  # require 'support/models/car'
-  # require 'support/models/driver'
-  # require 'support/models/passenger'
-  # require 'support/models/engine'
-  # require 'support/models/seat'
-  # require 'support/models/wheel'
-
   context "one :driver (link)" do
     subject { Car.new }
 
@@ -71,6 +64,7 @@ describe Ripple::NestedAttributes, :integration => true do
     it { should respond_to(:passengers_attributes=) }
 
     it "should not have passengers" do
+      pending("Linked associations are deprecated")
       subject.passengers.should == []
     end
 
@@ -82,16 +76,19 @@ describe Ripple::NestedAttributes, :integration => true do
                                                     { :name => 'Pat' } ] ) }
 
       it "should have 3 passengers" do
+        pending("Linked associations are deprecated")
         subject.passengers.size.should == 3
       end
 
       it "should have 3 passengers with specified names" do
+        pending("Linked associations are deprecated")
         subject.passengers.first.name.should == 'Joe'
         subject.passengers.second.name.should == 'Sue'
         subject.passengers.third.name.should == 'Pat'
       end
 
       it "should save the children when saving the parent" do
+        pending("Linked associations are deprecated")
         subject.save
         found_subject = Car.find(subject.key)
         found_subject.passengers.map(&:name).should =~ %w[ Joe Sue Pat ]
@@ -111,10 +108,12 @@ describe Ripple::NestedAttributes, :integration => true do
       end
 
       it "should have 3 passengers" do
+        pending("Linked associations are deprecated")
         subject.passengers.size.should == 3
       end
 
       it "should update attributes" do
+        pending("Linked associations are deprecated")
         subject.passengers_attributes = [ { :key => passenger1.key, :name => 'UPDATED One' },
                                           { :key => passenger2.key, :name => 'UPDATED Two' },
                                           { :key => passenger3.key, :name => 'UPDATED Three' } ]
@@ -124,6 +123,7 @@ describe Ripple::NestedAttributes, :integration => true do
       end
 
       it "should not save the child if attributes haven't been updated" do
+        pending("Linked associations are deprecated")
         subject.passengers.each do |passenger|
           passenger.should_not_receive(:save)
         end
@@ -131,6 +131,7 @@ describe Ripple::NestedAttributes, :integration => true do
       end
 
       it "should save the child when saving the parent" do
+        pending("Linked associations are deprecated")
         subject.passengers_attributes = [ { :key => passenger1.key, :name => 'UPDATED One' },
                                           { :key => passenger2.key, :name => 'UPDATED Two' },
                                           { :key => passenger3.key, :name => 'UPDATED Three' } ]

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -1,14 +1,23 @@
 require 'riak_test_server'
 
-TEST_SERVER_HTTP_PORT = 17017
-TEST_SERVER_PB_PORT = 17018
+TEST_SERVER_PB_PORT = 10500
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    RiakTestServer.setup(
+      protocol: 'pbc',
+      pb_port: TEST_SERVER_PB_PORT,
+      container_name: "ripple_tests"
+    )
+  end
+
   config.before(:each, integration: true) do
+    RiakTestServer.clear
     Ripple.config = {
+      protocol: 'pbc',
       nodes: [
         {
-          host: "localhost",
+          host: "docker",
           pb_port: TEST_SERVER_PB_PORT
         }
       ]


### PR DESCRIPTION
As of the 2.0 release of the Ruby Riak client, link walking has been
removed and is no longer supported. The implication here is that linked
associations no longer work in Ripple and silently fail when used. When
attempting to link walk, Ripple eats any exception raised and returns
an empty array - giving the appearance that all is well.

This deprecates linked associations, marks all related specs as
pending (they fail on master as-is), and targets full removal for
a future version of Ripple. No equivalent replacement will be provided at
this time; embedded and stored key associations should be used instead.
The deprecation and future removal should be safe as I've verified that
both Core and Id do not use linked associations - only embedded
associations are used.

Additionally, the test suite will now use the Docker based [Riak Test
Server](https://github.com/spreedly/riak_test_server) instead of Basho's defunct Vagrant virtual machine.

Ref: https://github.com/spreedly/ripple/pull/3
Ref: https://github.com/basho/riak-ruby-client/issues/191