### PR TITLE
Support for Rails 5.0

### DIFF
--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,0 +1,3 @@
+gem 'activemodel', '~> 5.0.7'
+
+instance_eval File.read(File.expand_path('../Gemfile', __FILE__))

--- a/lib/ripple/attribute_methods.rb
+++ b/lib/ripple/attribute_methods.rb
@@ -66,7 +66,7 @@ module Ripple
     # @param [Hash] attrs the attributes to assign
     # @param [Hash] options assignment options
     def assign_attributes(attrs, options={})
-      raise ArgumentError, t('attribute_hash') unless(Hash === attrs)
+      raise ArgumentError, t('attribute_hash') unless(attrs.respond_to?(:each))
 
       attrs = sanitize_for_mass_assignment(attrs)
 

--- a/lib/ripple/callbacks.rb
+++ b/lib/ripple/callbacks.rb
@@ -12,7 +12,7 @@ module Ripple
     included do
       extend ActiveModel::Callbacks
       define_model_callbacks *(CALLBACK_TYPES - [:validation])
-      define_callbacks :validation, :terminator => proc{|_,result| result == false}, :scope => [:kind, :name]
+      define_callbacks :validation, :terminator => proc{|_,result| result.call == false}, :scope => [:kind, :name]
     end
 
     module ClassMethods

--- a/lib/ripple/core_ext/casting.rb
+++ b/lib/ripple/core_ext/casting.rb
@@ -4,8 +4,8 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/date/conversions'
 require 'active_support/core_ext/date/zones'
+require 'active_support/core_ext/date_and_time/zones'
 require 'active_support/core_ext/date_time/conversions'
-require 'active_support/core_ext/date_time/zones'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/time/zones'
 require 'active_support/core_ext/string/conversions'
@@ -119,7 +119,8 @@ end
 # @private
 class DateTime
   def as_json(options={})
-    self.utc.to_s(Ripple.date_format)
+    datetime = self.utc.to_datetime
+    datetime.to_s(Ripple.date_format)
   end
 
   def self.ripple_cast(value)

--- a/lib/ripple/core_ext/indexes.rb
+++ b/lib/ripple/core_ext/indexes.rb
@@ -1,8 +1,8 @@
 require 'tzinfo'
 require 'active_support/core_ext/date/conversions'
 require 'active_support/core_ext/date/zones'
+require 'active_support/core_ext/date_and_time/zones'
 require 'active_support/core_ext/date_time/conversions'
-require 'active_support/core_ext/date_time/zones'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/time/zones'
 require 'active_support/core_ext/string/conversions'
@@ -51,7 +51,8 @@ class DateTime
   def to_ripple_index(type)
     case type
     when 'bin'
-      utc.to_s(Ripple.date_format)
+      datetime = self.utc.to_datetime
+      datetime.to_s(Ripple.date_format)
     when 'int'
       (utc.to_f * 1000).round
     end

--- a/lib/ripple/version.rb
+++ b/lib/ripple/version.rb
@@ -1,3 +1,3 @@
 module Ripple
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end

--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
 
   gem.add_dependency "riak-client", "~> 2.6"
-  gem.add_dependency "activesupport", "~> 4.2.0"
-  gem.add_dependency "activemodel", "~> 4.2.0"
+  gem.add_dependency "activesupport", "~> 5.0.7"
+  gem.add_dependency "activemodel", "~> 5.0.7"
   gem.add_dependency "tzinfo"
 
   # Files

--- a/spec/ripple/callbacks_spec.rb
+++ b/spec/ripple/callbacks_spec.rb
@@ -46,6 +46,15 @@ describe Ripple::Callbacks do
       callbacks.should == [ :before, :around, :after ]
     end
 
+    it 'halts the callback chain when false is returned' do
+      callbacks = []
+      doc.before_save { callbacks << :before; false }
+      doc.after_save { callbacks << :after }
+      doc.around_save(lambda { callbacks << :around })
+      subject.save
+      callbacks.should == [ :before ]
+    end
+
     it "propagates callbacks to embedded associated documents" do
       callbacks = []
       doc.before_save { callbacks << :box }


### PR DESCRIPTION
Includes the following updates required to support Rails 5.0:

- Relax the strict Hash check in `assign_attributes`. On Rails 5.0,
the `params` hash no longer inherits from `HashWithIndifferentAccess`.
Since the call to `sanitize_for_mass_assignment` already converts the
params to a Hash, there's no need to require the caller to perform the
conversion.
- Remove `active_support/core_ext/date_time/zones` and replace with
`active_support/core_ext/date_and_time/zones`. The `date_time/zones`
core extension previously delegated to the `date_and_time/zones`
extension.
- As of the 5.0 version of ActiveModel, callbacks that use the `terminator`
option will now be provided with a result lambda that should be
invoked and compared against a value. If the result of lambda matches
the expected value, the callback chain will be halted.
- On Rails 5.0, Calling `utc`, `getlocal`, or `getutc` will now always return
instances of the `Time` object for `DateTime`. This change in
ActiveSupport broke a few Ripple tests. To resolve, we'll now convert
the time objects back to datetime objects before calling `to_s`.

Ref: https://github.com/rails/rails/pull/20868/commits/14a3bd520dd4bbf1247fd3e0071b59c02c115ce0
Ref: https://github.com/rails/rails/commit/e0deec2e68c7db74a9c8ed25d8e7eb178d30e6ca
Ref: https://github.com/rails/rails/commit/2386daabe7f8c979b453010dc0de3e1f6bbf859d
Ref: https://github.com/rails/rails/commit/ee5e476aad791e41c97f2a833f41bb5899d5252b