### PR TITLE
Support for Rails 5.1

### DIFF
--- a/lib/ripple/associations.rb
+++ b/lib/ripple/associations.rb
@@ -177,7 +177,13 @@ module Ripple
             end
           )
           runner = filtered_cbs.compile
-          runner.call(ActiveSupport::Callbacks::Filters::Environment.new(doc, false, nil, nil)).value
+          
+          env = ActiveSupport::Callbacks::Filters::Environment.new(doc, false, nil)
+          if kind == :before
+            runner.invoke_before(env)
+          else
+            runner.invoke_after(env)
+          end
         end
       end
     end

--- a/lib/ripple/nested_attributes.rb
+++ b/lib/ripple/nested_attributes.rb
@@ -143,36 +143,36 @@ module Ripple
 
 
     protected
-    
+
     def autosave
       @autosave_nested_attributes_for ||= {}
     end
-    
+
     def marked_for_destruction
       @marked_for_destruction ||= {}
     end
-    
+
     private
-    
+
     def save_nested_attributes_for_one_association(association_name)
-      send(association_name).save
+      throw(:abort) unless send(association_name).save
     end
-    
+
     def save_nested_attributes_for_many_association(association_name)
       send(association_name).map(&:save)
     end
-    
+
     def destroy_marked_for_destruction
       self.marked_for_destruction.each_pair do |association_name, resources|
         resources.map(&:destroy)
         send(association_name).reload
       end
     end
-    
+
     def destroy_nested_many_association(association_name)
       send(association_name).map(&:destroy)
     end
-    
+
     def assign_nested_attributes_for_one_association(association_name, attributes)
       association = self.class.associations[association_name]
       if association.embedded?
@@ -182,15 +182,15 @@ module Ripple
         assign_nested_attributes_for_one_linked_association(association_name, attributes)
       end
     end
-    
+
     def assign_nested_attributes_for_one_embedded_association(association_name, attributes)
       send(association_name).build(attributes.except(*UNASSIGNABLE_KEYS))
     end
-    
+
     def assign_nested_attributes_for_one_linked_association(association_name, attributes)
       attributes = attributes.stringify_keys
       options = nested_attributes_options[association_name]
-    
+
       if attributes[key_attr.to_s].blank? && !reject_new_record?(association_name, attributes)
         send(association_name).build(attributes.except(*UNASSIGNABLE_KEYS))
       else
@@ -201,16 +201,16 @@ module Ripple
         end
       end
     end
-    
+
     def assign_nested_attributes_for_many_association(association_name, attributes_collection)
       unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
         raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
       end
-    
+
       if attributes_collection.is_a? Hash
         attributes_collection = attributes_collection.sort_by { |index, _| index.to_i }.map { |_, attributes| attributes }
       end
-    
+
       association = self.class.associations[association_name]
       if association.embedded?
         assign_nested_attributes_for_many_embedded_association(association_name, attributes_collection)
@@ -219,7 +219,7 @@ module Ripple
         assign_nested_attributes_for_many_linked_association(association_name, attributes_collection)
       end
     end
-    
+
     def assign_nested_attributes_for_many_embedded_association(association_name, attributes_collection)
       options = nested_attributes_options[association_name]
       send(:"#{association_name}=", []) # Clobber existing
@@ -230,12 +230,12 @@ module Ripple
         end
       end
     end
-    
+
     def assign_nested_attributes_for_many_linked_association(association_name, attributes_collection)
       options = nested_attributes_options[association_name]
       attributes_collection.each do |attributes|
         attributes = attributes.stringify_keys
-    
+
         if attributes[key_attr.to_s].blank? && !reject_new_record?(association_name, attributes)
           send(association_name).build(attributes.except(*UNASSIGNABLE_KEYS))
         elsif existing_record = send(association_name).detect { |record| record.key.to_s == attributes[key_attr.to_s].to_s }

--- a/lib/ripple/version.rb
+++ b/lib/ripple/version.rb
@@ -1,3 +1,3 @@
 module Ripple
-  VERSION = "5.0.0"
+  VERSION = "5.1.0"
 end

--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
 
   gem.add_dependency "riak-client", "~> 2.6"
-  gem.add_dependency "activesupport", "~> 5.0.7"
-  gem.add_dependency "activemodel", "~> 5.0.7"
+  gem.add_dependency "activesupport", "~> 5.1.7"
+  gem.add_dependency "activemodel", "~> 5.1.7"
   gem.add_dependency "tzinfo"
 
   # Files

--- a/spec/ripple/callbacks_spec.rb
+++ b/spec/ripple/callbacks_spec.rb
@@ -46,9 +46,9 @@ describe Ripple::Callbacks do
       callbacks.should == [ :before, :around, :after ]
     end
 
-    it 'halts the callback chain when false is returned' do
+    it 'halts the callback chain when :abort is thrown' do
       callbacks = []
-      doc.before_save { callbacks << :before; false }
+      doc.before_save { callbacks << :before; throw(:abort) }
       doc.after_save { callbacks << :after }
       doc.around_save(lambda { callbacks << :around })
       subject.save

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
       protocol: 'pbc',
       nodes: [
         {
-          host: "docker",
+          host: "localhost",
           pb_port: TEST_SERVER_PB_PORT
         }
       ]


### PR DESCRIPTION
* `ActiveSupport::Callbacks::Filters::Environment` no longer supports
[run_block](https://github.com/rails/rails/blob/5-1-stable/activesupport/lib/active_support/callbacks.rb#L158); remove in propagate_callbacks_to_embedded_associations
* `ActiveSupport::Callbacks::CallbackSequence` [call method](https://github.com/rails/rails/commit/871ca21f6a1d65c0ec78cb5a9641411e2210460b#diff-1ecd313ff0ab827af30014553cf8918dL453) no longer
supported; update logic in propagate_callbacks_to_embedded_associations
to call invoke_before on the sequence for :before callbacks and
invoke_after for :after callbacks
* Need to explicitly [throw :abort to halt callback chain](https://blog.bigbinary.com/2016/02/13/rails-5-does-not-halt-callback-chain-when-false-is-returned.html) - update test of
this behavior in callbacks_spec

Finished in 5.07 seconds
653 examples, 0 failures, 16 pending